### PR TITLE
Update the template with our updated preferences

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,16 @@ default-members = [
 	"codegen-impl",
 	"codegen-macro",
 ]
+
+resolver = "2"
+
+[workspace.dependencies]
+codegen = { path = "codegen" }
+codegen-macro = { path = "codegen-macro" }
+codegen-impl = { path = "codegen-impl" }
+
+expectorate = "1"
+prettyplease = "0.2"
+proc-macro2 = "1"
+syn = { version = "2", features = ["parsing"] }
+quote = "1"

--- a/codegen-impl/Cargo.toml
+++ b/codegen-impl/Cargo.toml
@@ -2,11 +2,16 @@
 name = "codegen-impl"
 version = "0.0.1"
 authors = ["Adam H. Leventhal <ahl@oxidecomputer.com"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 description = "Main implementation crate for the code generation"
 repository = "https://github.com/ahl/codegen-template.git"
 
 [dependencies]
-quote = "1"
-proc-macro2 = "1"
+quote = { workspace = true }
+proc-macro2 = { workspace = true }
+
+[dev-dependencies]
+expectorate = { workspace = true }
+prettyplease = { workspace = true }
+syn = { workspace = true }

--- a/codegen-impl/src/lib.rs
+++ b/codegen-impl/src/lib.rs
@@ -16,11 +16,24 @@ pub fn do_codegen() -> TokenStream {
 mod tests {
     use crate::do_codegen;
 
+    // You can write simple tests that validate output, but those often require
+    // weird formatting that can be challenging to get right.
     #[test]
-    fn test() {
+    fn simple_test() {
         assert_eq!(
             do_codegen().to_string(),
             r#"fn print_hi () { println ! ("I guess this is working!") ; }"#
         );
+    }
+
+    // The expectorate crate makes for more comprehensible tests that are also
+    // easier to review. When code generation changes, expectorate makes it
+    // easy to update fixtures based on the new code.
+    #[test]
+    fn robust_test() {
+        let code = do_codegen();
+        let file = syn::parse2(code).expect("invalid codegen");
+        let actual = prettyplease::unparse(&file);
+        expectorate::assert_contents("tests/data/robust_test.rs", &actual);
     }
 }

--- a/codegen-impl/tests/data/robust_test.rs
+++ b/codegen-impl/tests/data/robust_test.rs
@@ -1,0 +1,3 @@
+fn print_hi() {
+    println!("I guess this is working!");
+}

--- a/codegen-macro/Cargo.toml
+++ b/codegen-macro/Cargo.toml
@@ -2,13 +2,13 @@
 name = "codegen-macro"
 version = "0.0.1"
 authors = ["Adam H. Leventhal <ahl@oxidecomputer.com"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 description = "Main implementation crate for the code generation"
 repository = "https://github.com/ahl/codegen-template.git"
 
-[dependencies]
-codegen-impl = { path = "../codegen-impl" }
-
 [lib]
 proc-macro = true
+
+[dependencies]
+codegen-impl = { workspace = true }

--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -2,12 +2,13 @@
 name = "codegen"
 version = "0.0.1"
 authors = ["Adam H. Leventhal <ahl@oxidecomputer.com"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 description = "Front-end crate for inclusion by consumers"
 repository = "https://github.com/ahl/codegen-template.git"
 
 [dependencies]
-codegen-macro = { path = "../codegen-macro" }
-codegen-impl = { path = "../codegen-impl" }
-rustfmt-wrapper = "0.1.0"
+codegen-macro = { workspace = true }
+codegen-impl = { workspace = true }
+prettyplease = { workspace = true }
+syn = { workspace = true }

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -8,14 +8,13 @@ pub use codegen_macro::*;
 // for use with a build.rs script.
 use codegen_impl::do_codegen;
 
-use rustfmt_wrapper::rustfmt;
-
 /// This is what we'd expect build.rs scripts to call if they wanted to use our
 /// code generator to create files rather than as macros. While one can see the
 /// output from macros using `cargo expand` it's much easier if the code is
-/// placed in a file. To make things even easier, we run the TokenStream
-/// through rustfmt first.
+/// placed in a file. To make things even easier to understand, we run the
+/// TokenStream through prettypretty please to format the code first.
 pub fn build() -> String {
     let code = do_codegen();
-    rustfmt(code).unwrap()
+    let parsed = syn::parse2(code).expect("invalid codegen");
+    prettyplease::unparse(&parsed)
 }

--- a/example-build/Cargo.toml
+++ b/example-build/Cargo.toml
@@ -2,7 +2,7 @@
 name = "example-build"
 version = "0.0.1"
 authors = ["Adam H. Leventhal <ahl@oxidecomputer.com>"]
-edition = "2018"
+edition = "2021"
 
 [build-dependencies]
-codegen = { path = "../codegen" }
+codegen = { workspace = true }

--- a/example-macro/Cargo.toml
+++ b/example-macro/Cargo.toml
@@ -2,7 +2,7 @@
 name = "example-macro"
 version = "0.0.1"
 authors = ["Adam H. Leventhal <ahl@oxidecomputer.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
-codegen = { path = "../codegen" }
+codegen = { workspace = true }


### PR DESCRIPTION
We've moved away from `rustfmt-wrapper`. While it would be nice to use the **actual** `rustfmt` algorithm, the wrapper was just too flaky. The `prettyplease` crate serves the purpose with the only small caveat that the code it outputs may not conform to `rustfmt` so automated checks for conformance need to be relaxed.

We've added the use of `expectorate`--it's been incredibly useful for generating and updating fixtures for tests. Updating the fixture is trivial; code review of changed fixtures is often more valuable than reviewing the actual code generation (which may be hard to follow).

This also makes the repo a proper workspace, updates to Rust edition 2021 from 2018, etc.